### PR TITLE
Update Picard to 2.26.8 to address Log4j critical vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## ## [Unreleased]
 
+## [2.26.8] - 2021-12-16
+### Added
+- Update Picard to 2.26.8 to address Log4j critical vulnerability [GHSA-jfh8-c2jp-5v3q](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q).
+
 ## [2.26.3] - 2021-10-19
 ### Added
 - Update Picard from 2.25.5 to 2.26.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blcdsdockerregistry/bl-base:1.1.0 AS builder
 
 # Use mamba to install tools and dependencies into /usr/local
-ARG PICARD_VERSION=2.26.3
+ARG PICARD_VERSION=2.26.8
 RUN mamba create -qy -p /usr/local \
     -c bioconda \
     picard-slim==${PICARD_VERSION}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Picard can be found on GitHub at [broadinstitute/picard](https://github.com/broa
 # Version
 | Tool | Version |
 |------|---------|
-| picard-slim | 2.26.3 |
+| picard-slim | 2.26.8 |
 | Java | 1.8 |
 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,9 @@
 Category: 'docker'
 Description: 'Docker repository for Picard'
 Maintainers: ['aholmes@mednet.ucla.edu']
-Contributors: ['Aaron Holmes', 'Helena Winata', 'Jieun Oh']
+Contributors: ['Aaron Holmes', 'Helena Winata', 'Jieun Oh', 'Takafumi Yamaguchi']
 Languages: ['Dockerfile']
 Tools: ['Picard']
-Version: ['2.26.3']
+Version: ['2.26.8']
 Purpose: 'A set of tools for manipulating SAM/BAM/CRAM and VCF file formats'
 References: 'https://github.com/broadinstitute/picard'


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->
## Checklist 

### Formatting

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)-[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [x] I have ensured that the version number update follows the [versioning standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+image+versioning+standardization).

- [x] I have updated the version number/dependencies and added my name to the maintainer list in the `Dockerfile`.

- [x] I have updated the version number/feature changes in the `README.md`.

<!--- This acknowledgement is optional if you do not want to be listed--->
- [x] I have updated the version number and added my name to the contributors list in the `metadata.yaml`.

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!---If any previous versions have bugs, add "deprecated" in the version tag and list the bug in the corresponding release--->
- [x] I have drafted the new version release with any additions/changes and have linked the `CHANGELOG.md` in the release. 

### Docker Hub Auto Build Rules

- [x] I have created automated build rules following [this page](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/How+to+set+up+automated+builds+for+Docker+Hub) and I have not manually pushed this Docker image to the `blcdsdockerregistry` on [Docker Hub](https://hub.docker.com).

### Docker Image Testing

- [x] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

#### My command: 

```
(base) [tyamaguchi@ip-0A12520A docker-Picard]$ docker run -u $(id -u):$(id -g) -it --rm blcdsdockerregistry/picard:2.26.3 picard SortSam --version
/usr/local/bin/picard: line 5: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
Version:2.26.3

(base) [tyamaguchi@ip-0A12520A docker-Picard]$ docker run -u $(id -u):$(id -g) -it --rm blcdsdockerregistry/picard:branch-dev picard SortSam --version
/usr/local/bin/picard: line 5: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
Version:2.26.8

(base) [tyamaguchi@ip-0A12520A output]$ docker run -u $(id -u):$(id -g) -v $(pwd):$(pwd) -it --rm blcdsdockerregistry/picard:branch-dev picard ValidateSamFile -I /hot/resources/SMC-HET/normal/bams/A-mini/n2/output/HG002.N-n2.bam
/usr/local/bin/picard: line 5: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
21:17:39.125 INFO  NativeLibraryLoader - Loading libgkl_compression.so from jar:file:/usr/local/share/picard-slim-2.26.8-0/picard.jar!/com/intel/gkl/native/libgkl_compression.so
[Thu Dec 16 21:17:39 GMT 2021] ValidateSamFile --INPUT /hot/resources/SMC-HET/normal/bams/A-mini/n2/output/HG002.N-n2.bam --MODE VERBOSE --MAX_OUTPUT 100 --IGNORE_WARNINGS false --VALIDATE_INDEX true --INDEX_VALIDATION_STRINGENCY EXHAUSTIVE --IS_BISULFITE_SEQUENCED false --MAX_OPEN_TEMP_FILES 8000 --SKIP_MATE_VALIDATION false --VERBOSITY INFO --QUIET false --VALIDATION_STRINGENCY STRICT --COMPRESSION_LEVEL 5 --MAX_RECORDS_IN_RAM 500000 --CREATE_INDEX false --CREATE_MD5_FILE false --GA4GH_CLIENT_SECRETS client_secrets.json --help false --version false --showHidden false --USE_JDK_DEFLATER false --USE_JDK_INFLATER false
[Thu Dec 16 21:17:39 GMT 2021] Executing as ?@0d05ea95c9ea on Linux 3.10.0-1127.19.1.el7.x86_64 amd64; OpenJDK 64-Bit Server VM 1.8.0_152-release-1056-b12; Deflater: Intel; Inflater: Intel; Provider GCS is not available; Picard version: Version:2.26.8
WARNING 2021-12-16 21:17:39     ValidateSamFile NM validation cannot be performed without the reference. All other validations will still occur.
No errors found
[Thu Dec 16 21:17:42 GMT 2021] picard.sam.ValidateSamFile done. Elapsed time: 0.06 minutes.
Runtime.totalMemory()=693633024
```
     
Update Picard to 2.26.8 to address Log4j critical vulnerability