### PR TITLE
Update Picard version to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2023-11-15
+### Added
+ - Update Picard 3.1.1
+
 ## [3.1.0] - 2023-09-19
 ### Added
  - Update Picard 3.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG MINIFORGE_VER=23.3.1-1
 FROM condaforge/mambaforge:${MINIFORGE_VER} AS builder
 
 # Use mamba to install tools and dependencies into /usr/local
-ARG PICARD_VERSION=3.1.0
+ARG PICARD_VERSION=3.1.1
 RUN mamba create -qy -p /usr/local \
     -c bioconda \
     -c conda-forge \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ UCLA CDS Dockerfile for Picard (picard-slim) from the Broad Institute. A set of 
 # Documentation
 
 Picard can be found on GitHub at [broadinstitute/picard](https://github.com/broadinstitute/picard).
-`picard.jar` can be found at `/usr/local/share/picard-slim-3.1.0-0/picard.jar`
+`picard.jar` can be found at `/usr/local/share/picard-slim-3.1.1-0/picard.jar`
 
 # Version
 | Tool | Version |
 |------|---------|
-| picard-slim | 3.1.0 |
+| picard-slim | 3.1.1 |
 | Java | 1.17 |
 
 ## References

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,7 +5,7 @@ Maintainers: ['selinawu@mednet.ucla.edu']
 Contributors: ['Aaron Holmes', 'Helena Winata', 'Jieun Oh', 'Takafumi Yamaguchi', 'Arpi Beshlikyan', 'Selina Wu', 'Beth Neilsen', 'Joseph Salmingo']
 Languages: ['Dockerfile']
 Tools: ['Picard']
-Version: ['3.1.0']
+Version: ['3.1.1']
 Purpose: 'A set of tools for manipulating SAM/BAM/CRAM and VCF file formats'
 References: 'https://github.com/broadinstitute/picard'
 image_name: 'picard'


### PR DESCRIPTION
## Checklist 

### Formatting

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)-[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [X] I have ensured that the version number update follows the [versioning standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3188472/Docker+image+versioning+standardization).

- [X] I have updated the version number/dependencies and added my name to the maintainer list in the `Dockerfile`.

- [X] I have updated the version number/feature changes in the `README.md`.

- [X] I have updated the version number and added my name to the contributors list in the `metadata.yaml`.

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have drafted the new version release with any additions/changes and have linked the `CHANGELOG.md` in the release. 

### Docker Hub Auto Build Rules

- [X] I have created automated build rules following [this page](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3200420/How+to+set+up+automated+builds+for+Docker+Hub+deprecated) and I have not manually pushed this Docker image to the `blcdsdockerregistry` on [Docker Hub](https://hub.docker.com).

### Docker Image Testing

- [ ] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

#### My command: 

```docker run -u $(id -u):$(id -g) -it --rm picard311 picard SortSam --version```
/usr/local/bin/picard: line 5: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
Version:3.1.1
```docker run -u $(id -u):$(id -g) -v $(pwd):/home -it --rm picard311 picard ValidateSamFile -I /home/HG002.N-n2.bam```
/usr/local/bin/picard: line 5: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
Nov 15, 2023 8:53:41 PM com.intel.gkl.NativeLibraryLoader load
INFO: Loading libgkl_compression.so from jar:file:/usr/local/share/picard-slim-3.1.1-0/picard.jar!/com/intel/gkl/native/libgkl_compression.so
[Wed Nov 15 20:53:42 GMT 2023] ValidateSamFile --INPUT /home/HG002.N-n2-adjust.bam --MODE VERBOSE --MAX_OUTPUT 100 --IGNORE_WARNINGS false --VALIDATE_INDEX true --INDEX_VALIDATION_STRINGENCY EXHAUSTIVE --IS_BISULFITE_SEQUENCED false --MAX_OPEN_TEMP_FILES 8000 --SKIP_MATE_VALIDATION false --VERBOSITY INFO --QUIET false --VALIDATION_STRINGENCY STRICT --COMPRESSION_LEVEL 5 --MAX_RECORDS_IN_RAM 500000 --CREATE_INDEX false --CREATE_MD5_FILE false --help false --version false --showHidden false --USE_JDK_DEFLATER false --USE_JDK_INFLATER false
[Wed Nov 15 20:53:42 GMT 2023] Executing as ?@ac26099c947a on Linux 3.10.0-1160.92.1.el7.x86_64 amd64; OpenJDK 64-Bit Server VM 21.0.1-internal-adhoc.conda.src; Deflater: Intel; Inflater: Intel; Provider GCS is available; Picard version: Version:3.1.1
WARNING 2023-11-15 20:53:42     ValidateSamFile NM validation cannot be performed without the reference. All other validations will still occur.
No errors found
[Wed Nov 15 20:53:44 GMT 2023] picard.sam.ValidateSamFile done. Elapsed time: 0.04 minutes.
Runtime.totalMemory()=538968064

## Description

Updates Picard to v3.1.1
Closes #33 
